### PR TITLE
Release workflow update for trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,10 +17,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '>=23.6.0'
           registry-url: 'https://registry.npmjs.org'
-        env:
-            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.19'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   release-wasm-npm:
+    name: Release NPM package
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,23 +19,31 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+        env:
+            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           override: true
+
       - name: Install wasm-pack
         run: cargo install wasm-pack
+
       - name: Build WASM package
         run: wasm-pack build --target nodejs --scope apollo --out-name qp-analyzer
         working-directory: crates/wasm
+
       - name: Fix package json
         run: node scripts/fix-package-json.js
         working-directory: crates/wasm
+
       - name: Run tests
         run: npm test
         working-directory: crates/wasm/tests
+
       - name: Publish to npm
         run: npm publish --access public --provenance
         working-directory: crates/wasm/pkg


### PR DESCRIPTION
Node version needed to be updated to 23, since node 20 nor 22 didn't work.
`NODE_AUTH_TOKEN` wasn't necessary.